### PR TITLE
define and implement `ConstantTime{Partial,}Ord` traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl From<u8> for Choice {
     }
 }
 
-/// An `Eq`-like trait that produces a `Choice` instead of a `bool`.
+/// An [`Eq`]-like trait that produces a `Choice` instead of a `bool`.
 ///
 /// # Example
 ///
@@ -822,7 +822,20 @@ pub trait ConstantTimePartialOrd {
 ///
 /// This method requires a whole set of logical checks to be performed before evaluating their
 /// result, and uses a lookup table to avoid branching in a `match` expression.
-fn index_mutually_exclusive_logical_results<T, const N: usize>(
+///
+///```
+/// use subtle_ng::index_mutually_exclusive_logical_results;
+///
+/// let r = [0xA, 0xB, 0xC];
+///
+/// let a = index_mutually_exclusive_logical_results(&r, [0.into(), 0.into()]);
+/// assert_eq!(*a, 0xA);
+/// let b = index_mutually_exclusive_logical_results(&r, [1.into(), 0.into()]);
+/// assert_eq!(*b, 0xB);
+/// let c = index_mutually_exclusive_logical_results(&r, [0.into(), 1.into()]);
+/// assert_eq!(*c, 0xC);
+///```
+pub fn index_mutually_exclusive_logical_results<T, const N: usize>(
     results: &[T],
     logicals: [Choice; N],
 ) -> &T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -856,7 +856,7 @@ impl<T: ConstantTimeGreater + ConstantTimeLess + ConstantTimeEq> ConstantTimePar
         let is_lt = self.ct_lt(other);
         let is_gt = self.ct_gt(other);
 
-        const PARTIAL_ORDERS: [CtOption<Ordering>; 4] = [
+        static PARTIAL_ORDERS: [CtOption<Ordering>; 4] = [
             CtOption {
                 value: Ordering::Equal,
                 is_some: Choice::of_bool(false),
@@ -909,7 +909,7 @@ impl<T: ConstantTimeEq + ConstantTimeGreater> ConstantTimeOrd for T {
         let is_gt = self.ct_gt(other);
         let is_eq = self.ct_eq(other);
 
-        const ORDERS: [Ordering; 3] = [Ordering::Less, Ordering::Greater, Ordering::Equal];
+        static ORDERS: [Ordering; 3] = [Ordering::Less, Ordering::Greater, Ordering::Equal];
         *index_mutually_exclusive_logical_results(&ORDERS, [is_gt, is_eq])
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // -*- mode: rust; -*-
 //
 // This file is part of subtle, part of the dalek cryptography project.
-// Copyright (c) 2016-2018 isis lovecruft, Henry de Valence
+// Copyright (c) 2016-2022 isis lovecruft, Henry de Valence
 // See LICENSE for licensing information.
 //
 // Authors:
@@ -12,7 +12,6 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/subtle-ng/2.5.0")]
-
 
 #[cfg(feature = "std")]
 #[macro_use]
@@ -728,7 +727,7 @@ macro_rules! generate_unsigned_integer_greater {
                 Choice::from((bit & 1) as u8)
             }
         }
-    }
+    };
 }
 
 generate_unsigned_integer_greater!(u8, 8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,6 +818,18 @@ pub trait ConstantTimePartialOrd {
     fn ct_partial_cmp(&self, other: &Self) -> CtOption<Ordering>;
 }
 
+impl ConstantTimeEq for Ordering {
+    /// Use our `#[repr(i8)]` to get a `ct_eq()` implementation without relying on any `match`es.
+    ///
+    /// This also means `CtOption<Ordering>` implements `ConstantTimeEq`.
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Choice {
+        let a = *self as i8;
+        let b = *other as i8;
+        a.ct_eq(&b)
+    }
+}
+
 /// Select among `N + 1` results given `N` logical values, of which at most one should be true.
 ///
 /// This method requires a whole set of logical checks to be performed before evaluating their


### PR DESCRIPTION
dalek-cryptography/subtle#79 proposed a `ConstantTimePartialOrd` trait, but this was abandoned since (I am guessing) there wasn't a clear general use case, and there were concerns about how to create an `Ordering` without the use of `match`. This PR describes a general use case for constant-time ordering, and amends that PR with a naive attempt to avoid branching when creating an `Ordering`.

### Use Case

In the signal rust codebase, we (I am not affiliated with Signal) [handroll a function `constant_time_cmp()` to essentially implement `Ord` for `[u8]` slices](https://github.com/signalapp/libsignal/blob/2a46a5b2941f4a05e55406d2b28aae53a4e283e2/rust/protocol/src/utils.rs#L53-L82), which we use to [directly implement `Ord` for our public keys](https://github.com/signalapp/libsignal/blob/2a46a5b2941f4a05e55406d2b28aae53a4e283e2/rust/protocol/src/curve.rs#L179-L187). I was going to expose that method to our API consumers in signalapp/libsignal#469, but I was [advised to raise this use case to the `subtle-ng` crate instead](https://github.com/signalapp/libsignal/pull/469#issuecomment-1170613608).

Signal ends up [consuming the `Ord` impl for public keys in our client library's FFI](https://github.com/signalapp/libsignal/blob/2a46a5b2941f4a05e55406d2b28aae53a4e283e2/rust/bridge/shared/src/protocol.rs#L118-L125), which is then [used to implement `Ord` interfaces in the foreign languages](https://github.com/signalapp/libsignal/blob/2a46a5b2941f4a05e55406d2b28aae53a4e283e2/java/shared/java/org/signal/libsignal/protocol/ecc/ECPublicKey.java#L93).

**I think that if the proposed solution correctly achieves constant-time comparisons, it would benefit users of this library, who can now avoid hand-rolling their own `Ord` implementations which may not have been audited to correctly run in constant time.**

### Proposed Solution
1. Define traits `ConstantTime{PartialOrd,Ord}` which return either a `CtOption<Ordering>` or an `Ordering`.
    - These are implemented automatically for types implementing `ConstantTime{Eq,Greater}`.

**Note: I do not know if this implementation correctly avoids branching in the implementation of `ct_cmp`. It is directly based off of the code in dalek-cryptography/subtle#79, adding the use of a lookup table `ORDERS` instead of a `match`.**

### Result
Consumers of this library were already able to impl `core::cmp::{Partial,}Eq` with `ConstantTimeEq` to make `ConstantTimeEq` implementors usable as keys in `HashSet`s, for example. This change provides a safe constant-time implementation of an equivalent to `core::cmp::{Partial,}Ord` so that users can ensure constant-time comparisons between keys in an ordered collection such as `BTreeSet` as well.