### PR TITLE
reduce boilerplate implementing comparisons for user-defined types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -703,7 +703,7 @@ macro_rules! generate_unsigned_integer_greater {
             ///
             /// # Note
             ///
-            /// This algoritm would also work for signed integers if we first
+            /// This algorithm would also work for signed integers if we first
             /// flip the top bit, e.g. `let x: u8 = x ^ 0x80`, etc.
             #[inline]
             fn ct_gt(&self, other: &$t_u) -> Choice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/subtle-ng/2.5.0")]
 
-
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
@@ -728,7 +727,7 @@ macro_rules! generate_unsigned_integer_greater {
                 Choice::from((bit & 1) as u8)
             }
         }
-    }
+    };
 }
 
 generate_unsigned_integer_greater!(u8, 8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,12 +185,7 @@ impl From<u8> for Choice {
 pub trait ConstantTimeEq {
     /// Determine if two items are equal.
     ///
-    /// The `ct_eq` function should execute in constant time. When collections of elements which may
-    /// have different lengths must be compared, a strategy such as [shortlex] may be used to avoid
-    /// leaking timing info based on the contents of the collection. This is how
-    /// `ConstantTimeEq` is implemented for slices.
-    ///
-    /// [shortlex]: https://en.wikipedia.org/wiki/Shortlex_order
+    /// The `ct_eq` function should execute in constant time.
     ///
     /// # Returns
     ///
@@ -674,12 +669,7 @@ pub trait ConstantTimeGreater {
     /// The bitwise-NOT of the return value of this function should be usable to
     /// determine if `self <= other`.
     ///
-    /// This function should execute in constant time. When collections of elements which may have
-    /// different lengths must be compared, a strategy such as [shortlex] may be used to avoid
-    /// leaking timing info based on the contents of the collection. This is how
-    /// `ConstantTimeGreater` is implemented for slices.
-    ///
-    /// [shortlex]: https://en.wikipedia.org/wiki/Shortlex_order
+    /// This function should execute in constant time.
     ///
     /// # Returns
     ///
@@ -815,21 +805,13 @@ impl<T: ConstantTimeGreater + ConstantTimeEq> ConstantTimeGreater for [T] {
 
 /// A type which can be compared in some manner and be determined to be less
 /// than another of the same type.
+///
+/// This trait is automatically implemented for implementors of
+/// `ConstantTimeGreater+ConstantTimeEq`.
 pub trait ConstantTimeLess {
     /// Determine whether `self < other`.
     ///
-    /// The bitwise-NOT of the return value of this function should be usable to
-    /// determine if `self >= other`.
-    ///
-    /// A default implementation is provided and implemented for the unsigned
-    /// integer types.
-    ///
-    /// This function should execute in constant time. When collections of elements which may have
-    /// different lengths must be compared, a strategy such as [shortlex] may be used to avoid
-    /// leaking timing info based on the contents of the collection. This is how `ConstantTimeLess`
-    /// is implemented for slices.
-    ///
-    /// [shortlex]: https://en.wikipedia.org/wiki/Shortlex_order
+    /// This function should execute in constant time.
     ///
     /// # Returns
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // -*- mode: rust; -*-
 //
 // This file is part of subtle, part of the dalek cryptography project.
-// Copyright (c) 2016-2018 isis lovecruft, Henry de Valence
+// Copyright (c) 2016-2022 isis lovecruft, Henry de Valence
 // See LICENSE for licensing information.
 //
 // Authors:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -739,7 +739,7 @@ generate_unsigned_integer_greater!(u128, 128);
 
 /// A type which can be compared in some manner and be determined to be less
 /// than another of the same type.
-pub trait ConstantTimeLess: ConstantTimeEq + ConstantTimeGreater {
+pub trait ConstantTimeLess {
     /// Determine whether `self < other`.
     ///
     /// The bitwise-NOT of the return value of this function should be usable to
@@ -775,15 +775,16 @@ pub trait ConstantTimeLess: ConstantTimeEq + ConstantTimeGreater {
     ///
     /// assert_eq!(x_lt_x.unwrap_u8(), 0);
     /// ```
+    fn ct_lt(&self, other: &Self) -> Choice;
+}
+
+impl<T: ConstantTimeGreater + ConstantTimeEq> ConstantTimeLess for T {
+    /// Default implementation for whether `self < other`.
+    ///
+    /// This function should execute in constant time.
     #[inline]
     fn ct_lt(&self, other: &Self) -> Choice {
         !self.ct_gt(other) & !self.ct_eq(other)
     }
 }
 
-impl ConstantTimeLess for u8 {}
-impl ConstantTimeLess for u16 {}
-impl ConstantTimeLess for u32 {}
-impl ConstantTimeLess for u64 {}
-#[cfg(feature = "i128")]
-impl ConstantTimeLess for u128 {}


### PR DESCRIPTION
### Problem

In signalapp/libsignal#469, we discussed having to hand-roll a constant-time comparison function for a public key with a slice of bytes and an enum tag. After seeing dalek-cryptography/subtle#78 where we implement `ConstantTimeEq` for slices, I realized we could extend this method of iterated constant-time computation to make it more fluent to implement comparison operations for structs with multiple fields.

### Proposed Solution
1. Introduce `IteratedOperation` and `IteratedEq` to modularize the approach used in the existing `ConstantTimeEq` impl for slices.
    - Add a doctest demonstrating how to apply this to user structs with multiple fields.
1. Develop a novel method to calculate `ConstantTimeGreater` over a collection of elements as `IteratedGreater`.
    - Implement `ConstantTimeGreater` for slices using `IteratedGreater`.
1. Expose a `Convertible` trait which implements `ConstantTime{Eq,Greater,Less}` for structs which can be cheaply converted into a constant-time comparable type.

### Result
- It is now much nicer to support constant-time comparisons with custom structs, and doctests are provided to demonstrate this.
- `ConstantTimeOrd` will be implemented automatically for slices if/when #5 is merged.