### PR TITLE
chore: cleanup `toml`, `README`, `etc.`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: nightly
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features nightly
       - name: no-default-features
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,11 @@ authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"
 license = "BSD-3-Clause"
-repository = "https://github.com/dalek-cryptography/subtle"
-homepage = "https://dalek.rs/"
-documentation = "https://docs.rs/subtle"
+repository = "https://github.com/zkcrypto/subtle-ng"
+documentation = "https://docs.rs/subtle-ng"
 categories = ["cryptography", "no-std"]
 keywords = ["cryptography", "crypto", "constant-time", "utilities"]
 description = "Pure-Rust traits and utilities for constant-time cryptographic implementations."
-exclude = [
-    "**/.gitignore",
-    ".travis.yml",
-]
-
-[badges]
-travis-ci = { repository = "dalek-cryptography/subtle", branch = "master"}
 
 [dev-dependencies]
 rand = { version = "0.7" }
@@ -30,4 +22,3 @@ rand = { version = "0.7" }
 default = ["std", "i128"]
 std = []
 i128 = []
-nightly = []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # subtle-ng
 
+[![crates.io](https://img.shields.io/crates/v/subtle-ng.svg)](https://crates.io/crates/subtle-ng)
+[![Released API docs](https://docs.rs/subtle-ng/badge.svg)](https://docs.rs/subtle-ng)
+[![BSD 3-Clause licensed](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](./LICENSE)
+[![CI](https://github.com/zkcrypto/subtle-ng/workflows/Test/badge.svg)](https://github.com/zkcrypto/subtle-ng/actions?query=workflow%3ATest)
+
 **Pure-Rust traits and utilities for constant-time cryptographic implementations.**
 
 It consists of a `Choice` type, and a collection of traits using `Choice`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,6 @@ cargo-fuzz = true
 
 [dependencies.subtle]
 path = ".."
-features = ["nightly"]
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 


### PR DESCRIPTION
`exclude` is outdated (no more `.travis.yml`), and also unnecessary `.gitignore` is automatically included).

URLs and badges are outdated.

`nightly` feature seems unused.